### PR TITLE
[codex] Update internship timeline

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,9 +29,15 @@ const timelineEntries = [
   },
 
   {
-    year: 'Mar 2026 -',
-    title: 'Software Engineer Intern @ Tencent WXG',
-    subtitle: 'Development of Wechat Built-in AI Assistant',
+    year: 'Mar 2026 - Jun 2026',
+    title: 'Software Engineering Intern @ Tencent',
+    subtitle: "Development of WeChat's Built-in AI Assistant, Xiaowei",
+    details: '',
+  },
+  {
+    year: 'Jun 2026 -',
+    title: 'Software Engineering Intern @ Google',
+    subtitle: '',
     details: '',
   },
 ];


### PR DESCRIPTION
## Summary

- Mark the Tencent internship as ending in June 2026.
- Add the Google software engineering internship timeline entry.
- Update the Tencent subtitle to mention WeChat's Built-in AI Assistant, Xiaowei.

## Validation

- `npm run lint`

Generated by Codex on behalf of @jellllly420